### PR TITLE
Lower requirements to enable debian bookworm builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Cache files
 __pycache__
 rust/Cargo.lock
+*.swp
 
 # Build directories
 /rust/target/
@@ -11,3 +12,4 @@ rust/Cargo.lock
 # Generated files
 /python/i3switch/version.py
 /rust/Cargo.toml
+/rust/.cargo/config.toml

--- a/rust/.cargo/config.bookworm.toml
+++ b/rust/.cargo/config.bookworm.toml
@@ -1,0 +1,5 @@
+[source]
+[source.debian-packages]
+directory = "/usr/share/cargo/registry"
+[source.crates-io]
+replace-with = "debian-packages"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -1,13 +1,13 @@
 [package]
 name = "i3switch"
 version = "0.0.0" # This is a placeholder version
-edition = "2024"
+edition = "2021"
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 simplelog = "0.12"
 
 [dev-dependencies]
-ctor = "0.3"
+ctor = "0.1"

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -4,8 +4,16 @@ SOURCE_FILES := $(shell find src -name '*.rs')
 ROOT_DIR := $(shell realpath ..)
 VERSION := $(shell $(ROOT_DIR)/scripts/version.sh rs)
 .DEFAULT_GOAL := all
+OS_CODENAME=$(shell sed -e '/^VERSION_CODENAME/!d' -e 's/^.*=//' /etc/os-release)
 
-Cargo.toml: Cargo.toml.in
+.cargo/config.toml:
+ifeq ($(OS_CODENAME),bookworm)
+	ln -s config.bookworm.toml .cargo/config.toml
+else
+	echo > .cargo/config.toml
+endif
+
+Cargo.toml: Cargo.toml.in .cargo/config.toml
 	@echo "i3switch version: $(VERSION)"
 	sed "s|0.0.0|$(VERSION)|" Cargo.toml.in > Cargo.toml
 
@@ -33,6 +41,9 @@ all: dist/i3switch
 clean:
 	rm -rf dist
 	rm -rf target
+	rm -f Cargo.toml
+	rm -f Cargo.lock
+	rm -f .cargo/config.toml
 
 .PHONY: install
 install: target/release/i3switch

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -31,7 +31,7 @@ dist/i3switch: target/x86_64-unknown-linux-gnu/release/i3switch
 	cp target/x86_64-unknown-linux-gnu/release/i3switch dist/
 
 .PHONY: test
-test: $(SOURCE_FILES)
+test: Cargo.toml $(SOURCE_FILES)
 	cargo test
 
 .PHONY: all

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,7 +3,7 @@
 ### Requirements
 
 Requirements will be usually managed by cargo itself, unless distribution is known
-to manage Rust dependencies with packages manager, and `.cargo/config.<DISTRO>.toml`
+to manage Rust dependencies with packages manager, and `.cargo/config.<CODENAME>.toml`
 is available for that system.
 
 #### Debian Bookworm
@@ -16,6 +16,13 @@ To install requirements on debian bookworm, we use the package manager:
         librust-log-dev        \
         librust-serde-json-dev \
         librust-simplelog-dev
+
+#### Adding dependency restrictions
+
+If target distro manages Rust packages and building with crates.io is not preferred,
+a new restriction can be added by creating `.cargo/config.<SYSTEM_IDENTIFIER>.toml`
+and extending `Makefile` `.cargo/config.toml` target with condition for the distro,
+then documenting in a matching Requirements section in this README.
 
 ### Build
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,38 @@
+## i3switch Rust version
+
+### Requirements
+
+Requirements will be usually managed by cargo itself, unless distribution is known
+to manage Rust dependencies with packages manager, and `.cargo/config.<DISTRO>.toml`
+is available for that system.
+
+#### Debian Bookworm
+
+To install requirements on debian bookworm, we use the package manager:
+
+    sudo apt install           \
+        librust-clap-3-dev     \
+        librust-ctor-dev       \
+        librust-log-dev        \
+        librust-serde-json-dev \
+        librust-simplelog-dev
+
+### Build
+
+For most cases this should be enough:
+
+    make
+
+### Installation
+
+The output binary will be located in `dist/i3switch`. You can install it manually,
+or install to rust binary directory (must be in PATH to be usable) with:
+
+    make install                                   # install to local rust binary directory
+    sudo cp dist/i3switch /usr/local/bin/i3switch  # install to standard system directory
+
+### Tests
+
+To build tests just use make.
+
+    make test

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "256"] // Required for tests with older serde_json
 use clap::{Parser, ValueEnum, Subcommand, ArgAction};
 use std::process;
 use serde_json as json;
@@ -48,14 +48,14 @@ enum RootCommand {
     /// Switch focus to a specific tab/window number
     Number {
         /// The tab/window number to switch focus to
-        #[clap(value_parser)]
+        #[clap(value_parser, value_name="num")]
         number: u32,
     },
 }
 
 /// Define the wrap option for focus switching
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
-#[clap(rename_all = "lower", required = false)]
+#[clap(rename_all = "lower")]
 enum WrapOption {
     /// Enable wrap around
     Wrap,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use clap::{Parser, ValueEnum, Subcommand, ArgAction};
 use std::process;
 use serde_json as json;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, ValueEnum, Subcommand};
+use clap::{Parser, ValueEnum, Subcommand, ArgAction};
 use std::process;
 use serde_json as json;
 
@@ -13,20 +13,14 @@ use crate::logging::ResultExt;
 
 /// i3switch - A simple command-line utility to switch focus in i3 window manager
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Root command for focus switching
-    #[command(subcommand)]
+    #[clap(subcommand)]
     root_command: RootCommand,
 
     /// Wrap around when reaching the edge of the workspace
-    #[arg(
-        value_enum,
-        action = clap::ArgAction::Set,
-        default_value_t = WrapOption::NoWrap,
-        required = false,
-        global = true
-    )]
+    #[clap(arg_enum, action=ArgAction::Set, default_value = "nowrap", global = true)]
     wrap: WrapOption,
 }
 
@@ -53,18 +47,18 @@ enum RootCommand {
     /// Switch focus to a specific tab/window number
     Number {
         /// The tab/window number to switch focus to
-        #[arg(value_name = "num", required = true)]
+        #[clap(value_parser)]
         number: u32,
     },
 }
 
 /// Define the wrap option for focus switching
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "lower", required = false)]
 enum WrapOption {
     /// Enable wrap around
     Wrap,
     /// Disable wrap around
-    #[value(name = "nowrap")]
     NoWrap,
 }
 


### PR DESCRIPTION
Debian uses "2021" edition of Rust and manages rust packages by itself.
Added optional rust/.cargo/config.toml  that is created for debian, that prevents downloading packages from crates.io. Installing dependencies manually will be much cleaner than managing dependencies through rust cargo.
This required me to change argument parsing a little, it has additional help flag now, that I can't get rid of, but that doesn't affect its operation, so I'm fine to take that.