### PR TITLE
feat(rs): fall back to sway socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ abstraction of the manual tiling structure.
 
 For more history and motivation, see [history.md](docs/history.md).
 
+## Sway
+
+Since sway is mostly compatible with i3, rust version supports sway in i3 mode, by using
+sway socket for i3 IPC.
+
 ## Preview
 
 Preview demonstrates directional switching (without touching active tabs) and tab navigation


### PR DESCRIPTION
Wayland seems to be constructed in such a way to preserve compatibility with i3. Which is awesome, because just by getting the socket from sway, we can treat sway exactly the same as i3. So i3 mode should support sway without any real changes. And seems to do so.